### PR TITLE
Remove edit button from compact mode to prevent iframes stacking

### DIFF
--- a/nyuvm/templates/viewer.html
+++ b/nyuvm/templates/viewer.html
@@ -96,7 +96,9 @@
 		
 		<a class="btn btn-mini pull-right slidebutton" href="javascript:showmetadata({{collectionslide.id}});" id="{{collectionslide.id}}" ><i class="icon-info-sign"></i> Info</a><br clear="all">
 		{% if user in collectionslide.collection.authors.all or user.is_superuser %}
+		{% if not compact %}
 			<a class="btn btn-mini btn-primary pull-right slidebutton" href="{{URL_ROOT}}/editcollectionslide/{{collectionslide.id}}/" ><i class="icon-edit icon-white"></i> Edit</a><br clear="all">
+		{% endif %}
 		{% endif %}
 
 		{% if related_slides %}


### PR DESCRIPTION
Simply adds an extra condition as to when the edit button should be displayed.